### PR TITLE
Python3 dependency

### DIFF
--- a/afew.rb
+++ b/afew.rb
@@ -8,7 +8,7 @@ class Afew < Formula
   head "https://github.com/afewmail/afew.git"
 
    # dependencies of the tool
-  depends_on :python3
+  depends_on 'python3'
   depends_on "notmuch" => "with-python3"
 
   def install

--- a/space.rb
+++ b/space.rb
@@ -4,7 +4,7 @@ class Space < Formula
   head "https://github.com/samdmarshall/space.git"
 
   # dependencies of the tool
-  depends_on :python3
+  depends_on ':python3'
 
   def install
     pyver = Language::Python.major_minor_version "python3"

--- a/space.rb
+++ b/space.rb
@@ -4,7 +4,7 @@ class Space < Formula
   head "https://github.com/samdmarshall/space.git"
 
   # dependencies of the tool
-  depends_on ':python3'
+  depends_on 'python3'
 
   def install
     pyver = Language::Python.major_minor_version "python3"


### PR DESCRIPTION
Problem:
When I try to Tap this repository, I get the following error:
```
==> Tapping samdmarshall/formulae
Cloning into '/usr/local/Homebrew/Library/Taps/samdmarshall/homebrew-formulae'...
remote: Counting objects: 44, done.
remote: Compressing objects: 100% (38/38), done.
remote: Total 44 (delta 8), reused 18 (delta 4), pack-reused 0
Unpacking objects: 100% (44/44), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/samdmarshall/homebrew-formulae/space.rb
space: Unsupported special dependency :python3
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/samdmarshall/homebrew-formulae/afew.rb
afew: Unsupported special dependency :python3
Error: Cannot tap samdmarshall/formulae: invalid syntax in tap!
```
As Homebrew deprecated :python3 dependencies, we should change those dependencies.
I noted that you changed some files already, but not those. 

Thanks ;)